### PR TITLE
Add PDFTeX support with New TX fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog].
 ## Unreleased
 ### Added
 * Outline environment `\begin{outline}`
+* PDFTeX support
 
 ## 1.2 (released 2019-04-10)
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mla-tex
 
-Typeset your [MLA] papers in [XeTeX].
+Typeset your [MLA] papers in [LaTeX].
 
 ## Getting started
 
@@ -18,7 +18,8 @@ Start with the following template:
 
     \end{document}
 
-Compile as follows, or however you prefer to compile XeTeX:
+Compile as you like. The following example shows compilatation with
+XeTeX but all 3 engines are supported.
 
     $ latexmk -pdfxe -interaction=nonstopmode <document>.tex
 
@@ -48,7 +49,9 @@ You can cause text to be justified rather than left-aligned by
 providing the `[justify]` documentclass option.
 
 You can use [Tinos] for the main font rather than Times New Roman by
-providing the `[tinos]` documentclass option.
+providing the `[tinos]` documentclass option. This options only matters
+if you are using an OpenType-aware engine; compilation with PDFTeX will
+always use the [New TX font].
 
 You can prevent the Works Cited from being placed on a new page by
 providing the `[workscitedsamepage]` documentclass option.
@@ -133,4 +136,5 @@ by using the `header` and `centered` environments rather than the
 
 [mla]: https://owl.english.purdue.edu/owl/section/2/11/
 [tinos]: https://www.fontsquirrel.com/fonts/tinos
-[xetex]: http://xetex.sourceforge.net/
+[latex]: https://www.latex-project.org/
+[new tx font]: https://ctan.org/pkg/newtx

--- a/mla.cls
+++ b/mla.cls
@@ -6,6 +6,7 @@
 
 %% article uses 10pt by default.
 \LoadClass[12pt]{article}
+\RequirePackage{iftex}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%% Options
@@ -88,11 +89,17 @@
 %%%% Font
 
 %% Set the appropriate font (Tinos or Times New Roman).
-\usepackage{fontspec}
-\if@tinos
-\setmainfont{Tinos}
+% Load New TX if not using OpenType-compatible engine
+\iftutex
+  \usepackage{fontspec}
+  \if@tinos
+  \setmainfont{Tinos}
+  \else
+  \setmainfont{Times New Roman}
+  \fi
 \else
-\setmainfont{Times New Roman}
+  \RequirePackage[T1]{fontenc}
+  \RequirePackage{newtxtext}
 \fi
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
I'm not sure whether we should be using usepackage or RequirePackage. It seems like clsguide.pdf recommends the latter but it never explicitly advises against using the former? It's up to you, if you want I can change back to usepackage